### PR TITLE
fix: Kube context configuration logic fixed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,7 +70,7 @@ func Configure(logger hclog.Logger, config interface{}) (schema.ClientMeta, diag
 		logger.Debug("no context set in configuration using current default defined context", "context", kCfg.CurrentContext)
 		contexts = []string{kCfg.CurrentContext}
 	case 1:
-		if cfg.Contexts[0] != "*" {
+		if cfg.Contexts[0] == "*" {
 			logger.Debug("loading all available configuration")
 			for cName := range kCfg.Contexts {
 				contexts = append(contexts, cName)

--- a/client/client.go
+++ b/client/client.go
@@ -76,6 +76,9 @@ func Configure(logger hclog.Logger, config interface{}) (schema.ClientMeta, diag
 				contexts = append(contexts, cName)
 			}
 		} else {
+			if _, ok := kCfg.Contexts[cfg.Contexts[0]]; !ok {
+				return nil, diag.FromError(fmt.Errorf("context %q doesn't exist in kube configuration", cfg.Contexts[0]), diag.USER)
+			}
 			contexts = []string{cfg.Contexts[0]}
 		}
 	default:

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,5 +19,14 @@ export KUBECONFIG=<PATH_TO_YOUR_CONFIG_FILE>
 ```
 
 ### Configuration
-
-At the moment provider does not have any configuration.
+By default cloudquery fetches data from default context of the config. Context can be selected by setting contexts variable of provider's `configuration` block in `config.hcl`.  
+Example of context selection:
+```
+provider "k8s" {
+  configuration {
+    // Optional. Set contexts that you want to fetch. If it is not given then all contexts from config are iterated over.
+    contexts = ["one"]
+  }
+}
+```
+To fetch all the contexts set `contexts = ["*"]`

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,13 +19,13 @@ export KUBECONFIG=<PATH_TO_YOUR_CONFIG_FILE>
 ```
 
 ### Configuration
-By default cloudquery fetches data from default context of the config. Context can be selected by setting contexts variable of provider's `configuration` block in `config.hcl`.  
+By default cloudquery fetches data from default context of the kubernetes config. Context to fetch can be selected by setting contexts variable of provider's `configuration` block in `config.hcl`. 
 Example of context selection:
 ```
 provider "k8s" {
   configuration {
     // Optional. Set contexts that you want to fetch. If it is not given then all contexts from config are iterated over.
-    contexts = ["one"]
+    contexts = ["one", "two"]
   }
 }
 ```


### PR DESCRIPTION
- fixed wildcard context configuration `contexts = ["*"]`
- added check if selected context does not exist in configuration
- added docs for context configuration

closes #71 