### PR TITLE
fix: Added ignoring of 404 error when not supported resource fetched

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -22,12 +22,12 @@ func classifyError(err error, fallbackType diag.Type, opts ...diag.BaseErrorOpti
 	return diag.Diagnostics{diag.NewBaseError(err, fallbackType, opts...)}
 }
 
-func IgnoreForbidden(err error) bool {
+func IgnoreForbiddenNotFound(err error) bool {
 	statusError, ok := err.(k8s.APIStatus)
 	if !ok {
 		return false
 	}
-	if statusError.Status().Code == 403 {
+	if statusError.Status().Code == 403 || statusError.Status().Code == 404 {
 		return true
 	}
 	return false

--- a/resources/services/apps/daemon_sets.go
+++ b/resources/services/apps/daemon_sets.go
@@ -18,7 +18,7 @@ func DaemonSets() *schema.Table {
 		Resolver:     fetchDaemonSets,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/apps/deployments.go
+++ b/resources/services/apps/deployments.go
@@ -18,7 +18,7 @@ func Deployments() *schema.Table {
 		Resolver:     fetchAppsDeployments,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/apps/replica_sets.go
+++ b/resources/services/apps/replica_sets.go
@@ -18,7 +18,7 @@ func ReplicaSets() *schema.Table {
 		Resolver:     fetchAppsReplicaSets,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/apps/stateful_sets.go
+++ b/resources/services/apps/stateful_sets.go
@@ -18,7 +18,7 @@ func StatefulSets() *schema.Table {
 		Resolver:     fetchAppsStatefulSets,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/batch/cron_jobs.go
+++ b/resources/services/batch/cron_jobs.go
@@ -18,7 +18,7 @@ func CronJobs() *schema.Table {
 		Resolver:     fetchBatchCronJobs,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/batch/jobs.go
+++ b/resources/services/batch/jobs.go
@@ -18,7 +18,7 @@ func Jobs() *schema.Table {
 		Resolver:      fetchBatchJobs,
 		Multiplex:     client.ContextMultiplex,
 		DeleteFilter:  client.DeleteContextFilter,
-		IgnoreError:   client.IgnoreForbidden,
+		IgnoreError:   client.IgnoreForbiddenNotFound,
 		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		IgnoreInTests: true,
 		Columns: []schema.Column{

--- a/resources/services/core/endpoints.go
+++ b/resources/services/core/endpoints.go
@@ -19,7 +19,7 @@ func Endpoints() *schema.Table {
 		Resolver:     fetchCoreEndpoints,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/core/limit_ranges.go
+++ b/resources/services/core/limit_ranges.go
@@ -18,7 +18,7 @@ func LimitRanges() *schema.Table {
 		Resolver:     fetchCoreLimitRanges,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/core/namespaces.go
+++ b/resources/services/core/namespaces.go
@@ -17,7 +17,7 @@ func Namespaces() *schema.Table {
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
 		Resolver:     fetchCoreNamespaces,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/core/nodes.go
+++ b/resources/services/core/nodes.go
@@ -19,7 +19,7 @@ func Nodes() *schema.Table {
 		Resolver:     fetchCoreNodes,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/core/pods.go
+++ b/resources/services/core/pods.go
@@ -19,7 +19,7 @@ func Pods() *schema.Table {
 		Resolver:     fetchCorePods,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/core/resource_quotas.go
+++ b/resources/services/core/resource_quotas.go
@@ -18,7 +18,7 @@ func ResourceQuotas() *schema.Table {
 		Resolver:     fetchCoreResourceQuotas,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/core/service_accounts.go
+++ b/resources/services/core/service_accounts.go
@@ -18,7 +18,7 @@ func ServiceAccounts() *schema.Table {
 		Resolver:     fetchCoreServiceAccounts,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/core/services.go
+++ b/resources/services/core/services.go
@@ -19,7 +19,7 @@ func Services() *schema.Table {
 		Resolver:     fetchCoreServices,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/networking/network_policies.go
+++ b/resources/services/networking/network_policies.go
@@ -18,7 +18,7 @@ func NetworkPolicies() *schema.Table {
 		Resolver:     fetchNetworkingNetworkPolicies,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/rbac/role_bindings.go
+++ b/resources/services/rbac/role_bindings.go
@@ -18,7 +18,7 @@ func RoleBindings() *schema.Table {
 		Resolver:     fetchRbacRoleBindings,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,

--- a/resources/services/rbac/roles.go
+++ b/resources/services/rbac/roles.go
@@ -18,7 +18,7 @@ func Roles() *schema.Table {
 		Resolver:     fetchRbacRoles,
 		Multiplex:    client.ContextMultiplex,
 		DeleteFilter: client.DeleteContextFilter,
-		IgnoreError:  client.IgnoreForbidden,
+		IgnoreError:  client.IgnoreForbiddenNotFound,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"uid"}},
 		Columns: []schema.Column{
 			client.CommonContextField,


### PR DESCRIPTION
…esource

🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

When user tries to fetch a resource that is not supported in a fetched cluster (old version of kubernetes for example) the server returns `the server could not find the requested resource` and fails the fetch. 
NotFound error added to ignore errors filter to prevent such errors in future.
closes cloudquery/cloudquery-issues#328

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] Ensure the status checks below are successful ✅
