### PR TITLE
fix: Added `not found` errors to classifier

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -19,7 +19,7 @@ func classifyError(err error, fallbackType diag.Type, opts ...diag.BaseErrorOpti
 		case 403:
 			return diag.FromError(ie, diag.ACCESS, diag.WithSeverity(diag.WARNING), diag.WithDetails(se.Status().Details.String()))
 		case 404:
-			return diag.FromError(ie, diag.RESOLVING, diag.WithSeverity(diag.IGNORE), diag.WithDetails("Current version of k8s might not support requested resource"))
+			return diag.FromError(ie, diag.RESOLVING, diag.WithSeverity(diag.IGNORE), diag.WithDetails("Current version of k8s might not support the requested resource. Consider upgrading your k8s to the most recent version"))
 		}
 	}
 	return diag.Diagnostics{diag.NewBaseError(err, fallbackType, opts...)}

--- a/client/errors.go
+++ b/client/errors.go
@@ -19,7 +19,7 @@ func classifyError(err error, fallbackType diag.Type, opts ...diag.BaseErrorOpti
 		case 403:
 			return diag.FromError(ie, diag.ACCESS, diag.WithSeverity(diag.WARNING), diag.WithDetails(se.Status().Details.String()))
 		case 404:
-			return diag.FromError(ie, diag.RESOLVING, diag.WithSeverity(diag.IGNORE), diag.WithDetails("Current version of k8s might not support requested resource"))
+			return diag.FromError(ie, diag.RESOLVING, diag.WithSeverity(diag.IGNORE), diag.WithDetails("Current version of k8s might not support the requested resource"))
 		}
 	}
 	return diag.Diagnostics{diag.NewBaseError(err, fallbackType, opts...)}

--- a/client/errors.go
+++ b/client/errors.go
@@ -19,7 +19,7 @@ func classifyError(err error, fallbackType diag.Type, opts ...diag.BaseErrorOpti
 		case 403:
 			return diag.FromError(ie, diag.ACCESS, diag.WithSeverity(diag.WARNING), diag.WithDetails(se.Status().Details.String()))
 		case 404:
-			return diag.FromError(ie, diag.RESOLVING, diag.WithSeverity(diag.IGNORE), diag.WithDetails("Current version of k8s might not support the requested resource. Consider upgrading your k8s to the most recent version"))
+			return diag.FromError(ie, diag.RESOLVING, diag.WithSeverity(diag.IGNORE), diag.WithDetails("Current version of k8s might not support the requested resource. Consider upgrading k8s to the latest version"))
 		}
 	}
 	return diag.Diagnostics{diag.NewBaseError(err, fallbackType, opts...)}

--- a/client/errors.go
+++ b/client/errors.go
@@ -15,8 +15,11 @@ func ErrorClassifier(_ schema.ClientMeta, resourceName string, err error) diag.D
 func classifyError(err error, fallbackType diag.Type, opts ...diag.BaseErrorOption) diag.Diagnostics {
 	ie := errors.Unwrap(err)
 	if se, ok := ie.(k8s.APIStatus); ok {
-		if se.Status().Code == 403 {
+		switch se.Status().Code {
+		case 403:
 			return diag.FromError(ie, diag.ACCESS, diag.WithSeverity(diag.WARNING), diag.WithDetails(se.Status().Details.String()))
+		case 404:
+			return diag.FromError(ie, diag.RESOLVING, diag.WithSeverity(diag.IGNORE), diag.WithDetails("Current version of k8s might not support requested resource"))
 		}
 	}
 	return diag.Diagnostics{diag.NewBaseError(err, fallbackType, opts...)}


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

- adds `not found` errors to ErrorClassifier. k8s server returns 404 when not supported resource is fetched

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] Ensure the status checks below are successful ✅
