### PR TITLE
feat: YAML config support

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -1,12 +1,36 @@
 package client
 
+import "github.com/cloudquery/cq-provider-sdk/cqproto"
+
 type Config struct {
 	Contexts []string `hcl:"contexts,optional"`
+
+	requestedFormat cqproto.ConfigFormat
 }
 
-func (Config) Example() string {
-	return `configuration {
+func NewConfig(f cqproto.ConfigFormat) *Config {
+	return &Config{
+		requestedFormat: f,
+	}
+}
+
+func (c Config) Example() string {
+	switch c.requestedFormat {
+	case cqproto.ConfigHCL:
+		return `configuration {
   // Optional. Set contexts that you want to fetch. If it is not given then all contexts from config are iterated over.
   // contexts = ["YOUR_CONTEXT_NAME1", "YOUR_CONTEXT_NAME2"]
 }`
+	default:
+		return `
+Optional. Set contexts that you want to fetch. If it is not given then all contexts from config are iterated over.
+contexts:
+  - YOUR_CONTEXT_NAME1
+  - YOUR_CONTEXT_NAME2
+`
+	}
+}
+
+func (c Config) Format() cqproto.ConfigFormat {
+	return c.requestedFormat
 }

--- a/client/testing.go
+++ b/client/testing.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
@@ -22,8 +23,8 @@ func K8sTestHelper(t *testing.T, table *schema.Table, snapshotDirPath string) {
 			Name:      "k8s_mock_test_provider",
 			Version:   "development",
 			Configure: Configure,
-			Config: func() provider.Config {
-				return &Config{}
+			Config: func(f cqproto.ConfigFormat) provider.Config {
+				return NewConfig(f)
 			},
 			ResourceMap: map[string]*schema.Table{
 				"test_resource": table,
@@ -54,8 +55,8 @@ func K8sMockTestHelper(t *testing.T, table *schema.Table, builder func(*testing.
 			ResourceMap: map[string]*schema.Table{
 				"test_resource": table,
 			},
-			Config: func() provider.Config {
-				return &Config{}
+			Config: func(f cqproto.ConfigFormat) provider.Config {
+				return NewConfig(f)
 			},
 		},
 		Config: cfg,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-provider-k8s
 go 1.17
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.12.0
+	github.com/cloudquery/cq-provider-sdk v0.12.1
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-provider-k8s
 go 1.17
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.11.4
+	github.com/cloudquery/cq-provider-sdk v0.12.0
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.11.4 h1:/y/AB+/mKRGFoc0rLin3KRtfqc5eAooYjqdltrsGi8I=
-github.com/cloudquery/cq-provider-sdk v0.11.4/go.mod h1:q6hYy9S+XtKG8cyOiLG5gqSIkXEJ72MHQ316zW6DMiA=
+github.com/cloudquery/cq-provider-sdk v0.12.0 h1:S3AAkxmXhoGwvn7E77GmcOzkIFAxOjXEhPr+F0jW+Pg=
+github.com/cloudquery/cq-provider-sdk v0.12.0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.12.0 h1:S3AAkxmXhoGwvn7E77GmcOzkIFAxOjXEhPr+F0jW+Pg=
-github.com/cloudquery/cq-provider-sdk v0.12.0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.12.1 h1:Y4/VWjb/HLRX1pUoA7H82JoEu5mizNCDlfIeLGXOXSA=
+github.com/cloudquery/cq-provider-sdk v0.12.1/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/resources/provider/provider.go
+++ b/resources/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cloudquery/cq-provider-k8s/resources/services/core"
 	"github.com/cloudquery/cq-provider-k8s/resources/services/networking"
 	"github.com/cloudquery/cq-provider-k8s/resources/services/rbac"
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 )
@@ -23,8 +24,8 @@ func Provider() *provider.Provider {
 		Name:            ProviderName,
 		Configure:       client.Configure,
 		ErrorClassifier: client.ErrorClassifier,
-		Config: func() provider.Config {
-			return &client.Config{}
+		Config: func(f cqproto.ConfigFormat) provider.Config {
+			return client.NewConfig(f)
 		},
 		ResourceMap: map[string]*schema.Table{
 			"apps.daemon_sets":            apps.DaemonSets(),


### PR DESCRIPTION
to go with https://github.com/cloudquery/cq-provider-sdk/pull/332 and https://github.com/cloudquery/cloudquery/pull/887

`go run main.go init k8s --config config.yml` creates this:
```yaml
cloudquery:
    providers:
        - name: k8s
          version: latest
    connection:
        type: postgres
        username: postgres
        password: pass
        host: localhost
        port: 5432
        database: postgres
        sslmode: disable
providers:
    # provider configurations
    - name: k8s
      # Optional. Set contexts that you want to fetch. If it is not given then all contexts from config are iterated over.
      # contexts:
      #   - YOUR_CONTEXT_NAME1
      #   - YOUR_CONTEXT_NAME2
      #  
      # list of resources to fetch
      resources:
        - apps.daemon_sets
        - apps.deployments
        - apps.replica_sets
        - apps.stateful_sets
        - batch.cron_jobs
        - batch.jobs
        - core.endpoints
        - core.limit_ranges
        - core.namespaces
        - core.nodes
        - core.pods
        - core.resource_quotas
        - core.service_accounts
        - core.services
        - networking.network_policies
        - rbac.role_bindings
        - rbac.roles
```